### PR TITLE
サイトをモダンでリッチなデザインに刷新

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,230 +1,298 @@
-html[lang="ja"] {
-  height: 100%;
-  font-family: "Noto Sans JP", "Hiragino Kaku Gothic ProN", Meiryo, sans-serif;
+:root {
+  --bg: #06070d;
+  --bg-soft: #121528;
+  --text: #f2f5ff;
+  --muted: #b7c0de;
+  --accent: #ff335f;
+  --accent-2: #8c52ff;
+  --glass: rgba(255, 255, 255, 0.08);
+  --glass-border: rgba(255, 255, 255, 0.22);
+  --shadow: 0 20px 40px rgba(3, 8, 30, 0.45);
 }
 
-body,
-h1,
-h2,
-p,
-ul {
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
   margin: 0;
   padding: 0;
-}
-
-header {
-  background-color: #00000000;
-  color: white88;
-  padding: 10px 20px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  opacity: 0.99;
-  position: fixed;
-  top: 0;
-  width: 100%;
-  z-index: 1000;
-}
-
-#logo-container {
-  display: flex;
-  align-items: center;
-}
-
-#logo {
-  width: 20%;
-  height: auto;
-}
-
-#site-title {
-  font-size: 1.5em;
+  font-family: "Noto Sans JP", "Hiragino Kaku Gothic ProN", Meiryo, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  scroll-behavior: smooth;
 }
 
 body {
-  display: block;
-  height: 100%;
+  min-height: 100vh;
+  line-height: 1.7;
+}
+
+.bg-layer {
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at 10% 20%, #ff335f33, transparent 35%),
+    radial-gradient(circle at 80% 10%, #8c52ff44, transparent 32%),
+    radial-gradient(circle at 60% 80%, #ffffff20, transparent 28%),
+    linear-gradient(145deg, #070a14 10%, #090f23 60%, #0f1224 100%);
+  z-index: -1;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 5vw;
+  backdrop-filter: blur(14px);
+  background: rgba(6, 7, 13, 0.5);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.brand {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  text-decoration: none;
+  color: var(--text);
+}
+
+.brand-logo {
+  width: 52px;
+  height: 52px;
+  object-fit: contain;
+}
+
+.brand-text {
+  font-weight: 900;
+  letter-spacing: 0.1em;
+}
+
+.site-nav {
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+
+.site-nav a {
+  color: var(--muted);
+  text-decoration: none;
+  font-weight: 500;
+  transition: color 0.2s ease;
+}
+
+.site-nav a:hover {
+  color: #fff;
 }
 
 main {
-  display: block;
-}
-#contact-button {
-  display: block;
-  text-align: center;
+  width: min(1140px, 92vw);
+  margin: 0 auto;
 }
 
-.gradient4 {
+.hero {
+  min-height: 80vh;
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  align-items: center;
+  gap: 28px;
+  padding: 60px 0 30px;
+}
+
+.badge {
   display: inline-block;
-  padding: 18px 30px;
-  border-radius: 30px;
-  text-decoration: none;
-  background: linear-gradient(270deg, red 0%, #ffe140 50%, red 100%);
-  background-size: 200% auto;
-  color: white;
-  font-weight: bold;
-  transition: all 0.4s ease-out;
+  margin-bottom: 18px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  color: #ffe7ee;
+  background: linear-gradient(90deg, #ff335faa, #8c52ffaa);
 }
 
-.gradient4:hover {
-  border-color: transparent;
-  background: linear-gradient(270deg, #ffe140 0%, red 50%, #ffe140 100%);
-  background-size: 200% auto;
-  background-position: right center;
-}
-
-.overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(255, 255, 255, 0.5);
-  z-index: -1;
-}
-
-section {
-  margin-bottom: 80px;
-}
-
-p {
-  color: white;
-  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.3), -1px -1px 0 rgba(0, 0, 0, 0.3),
-    -1px 1px 0 rgba(0, 0, 0, 0.3), 1px -1px 0 rgba(0, 0, 0, 0.3),
-    0px 1px 0 rgba(0, 0, 0, 0.3), 0-1px 0 rgba(0, 0, 0, 0.3),
-    -1px 0 0 rgba(0, 0, 0, 0.3), 1px 0 0 rgba(0, 0, 0, 0.3);
-}
-
-h1 {
-  color: white;
-  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.3), -1px -1px 0 rgba(0, 0, 0, 0.3),
-    -1px 1px 0 rgba(0, 0, 0, 0.3), 1px -1px 0 rgba(0, 0, 0, 0.3),
-    0px 1px 0 rgba(0, 0, 0, 0.3), 0-1px 0 rgba(0, 0, 0, 0.3),
-    -1px 0 0 rgba(0, 0, 0, 0.3), 1px 0 0 rgba(0, 0, 0, 0.3);
-  margin: 0 0 20px 20px;
-  font-size: 180%;
-}
-h2 {
-  color: white;
-  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.3), -1px -1px 0 rgba(0, 0, 0, 0.3),
-    -1px 1px 0 rgba(0, 0, 0, 0.3), 1px -1px 0 rgba(0, 0, 0, 0.3),
-    0px 1px 0 rgba(0, 0, 0, 0.3), 0-1px 0 rgba(0, 0, 0, 0.3),
-    -1px 0 0 rgba(0, 0, 0, 0.3), 1px 0 0 rgba(0, 0, 0, 0.3);
-  margin: 40px 0 20px 30px;
-  font-size: 150%;
-}
-
-.map {
-  display: block;
-  width: 70%;
-  margin: 0 auto;
-}
-
-footer {
-  background-color: #333;
-  color: white;
-  text-align: center;
-  bottom: 0;
-  width: 100%;
-  position: relative;
-}
-
-footer a {
-  color: white;
-}
-
-footer a:hover {
-  color: red;
-  text-decoration: none;
-}
-
-.uniform_img {
-  width: 90vw;
-  margin: 0 auto;
-  height: auto;
-  display: block;
-}
-
-#about-blaze img {
-  width: 100%;
-  height: auto;
-}
-#page-top p {
+.hero h1 {
+  font-size: clamp(2rem, 5vw, 3.4rem);
+  line-height: 1.2;
   margin: 0;
 }
 
-#page-top a {
-  background: red;
-  color: white;
-  text-align: center;
+.hero h1 span {
+  background: linear-gradient(90deg, #ff4d79, #9f69ff);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.hero p {
+  color: var(--muted);
+}
+
+.hero-image-wrap {
+  border-radius: 26px;
+  overflow: hidden;
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--shadow);
+}
+
+.hero-image {
+  width: 100%;
+  height: 100%;
   display: block;
-  text-decoration: none;
-  padding: 20px;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  font-size: 0.8rem;
-  transition: all 0.3s;
+  object-fit: cover;
 }
 
-#page-top a:hover {
-  background: #777;
+.section {
+  margin-top: 72px;
 }
 
-#copylight {
-  padding: 2vh;
+.section-title {
+  margin: 0 0 18px;
+  font-size: clamp(1.5rem, 3vw, 2.1rem);
 }
 
-body.animation-in-progress {
-  overflow: auto;
+.glass-card {
+  background: var(--glass);
+  border: 1px solid var(--glass-border);
+  border-radius: 20px;
+  padding: 24px;
+  box-shadow: var(--shadow);
 }
 
-.bg {
-  animation: slide 10s ease-in-out infinite alternate;
-  background-image: linear-gradient(-70deg, white 50%, red 50%);
-  bottom: 0;
-  left: -50%;
-  opacity: 0.6;
-  position: fixed;
-  right: -50%;
-  top: 0;
-  z-index: -1;
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 18px;
 }
 
-.bg2 {
-  animation-direction: alternate-reverse;
-  animation-duration: 15s;
+.label {
+  margin: 0;
+  font-size: 0.82rem;
+  color: #d3daf4;
 }
 
-.bg3 {
-  animation-duration: 20s;
+.value {
+  margin: 6px 0 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #fff;
 }
 
-.content {
-  background-color: rgba(255, 255, 255, 0.8);
-  border-radius: 0.25em;
-  box-shadow: 0 0 0.25em rgba(0, 0, 0, 0.3);
-  box-sizing: border-box;
-  left: 50%;
-  padding: 10vmin;
-  position: fixed;
+.practice-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 18px;
+}
+
+.practice-card h3 {
+  margin: 0 0 8px;
+  font-size: 1.15rem;
+}
+
+.practice-card p {
+  margin: 4px 0;
+  color: var(--muted);
+}
+
+.practice-card iframe {
+  margin-top: 12px;
+  width: 100%;
+  height: 170px;
+  border: 0;
+  border-radius: 12px;
+}
+
+.uniform-card {
+  padding: 0;
+  overflow: hidden;
+}
+
+.uniform-card img {
+  width: 100%;
+  display: block;
+}
+
+.contact-card {
   text-align: center;
-  top: 50%;
-  transform: translate(-50%, -50%);
+  padding: 42px 24px;
+  border-radius: 24px;
+  background: linear-gradient(140deg, #ff335fdd, #8c52ffdd);
+  box-shadow: var(--shadow);
 }
 
-@keyframes slide {
-  0% {
-    transform: translateX(-25%);
+.contact-card h2 {
+  margin: 0;
+  font-size: clamp(1.4rem, 2.8vw, 2rem);
+}
+
+.contact-card p {
+  color: #fff;
+  margin: 12px 0 24px;
+}
+
+.cta-button {
+  display: inline-block;
+  text-decoration: none;
+  font-weight: 700;
+  color: #101222;
+  background: #fff;
+  padding: 12px 22px;
+  border-radius: 999px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.cta-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(255, 255, 255, 0.25);
+}
+
+.site-footer {
+  margin-top: 80px;
+  padding: 28px 4vw 36px;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  text-align: center;
+  color: var(--muted);
+}
+
+.site-footer a {
+  color: #fff;
+  text-decoration: none;
+}
+
+.page-top {
+  display: inline-block;
+  margin-bottom: 12px;
+}
+
+.privacy-section {
+  padding-top: 48px;
+}
+
+.privacy-card h2 {
+  margin: 24px 0 8px;
+  font-size: 1.1rem;
+}
+
+.privacy-card p {
+  margin: 0;
+  color: var(--muted);
+}
+
+@media (max-width: 900px) {
+  .hero {
+    grid-template-columns: 1fr;
+    min-height: auto;
+    padding-top: 30px;
   }
-  100% {
-    transform: translateX(25%);
+
+  .site-header {
+    position: static;
+    gap: 10px;
   }
-}
 
-#privacy-policy {
-  margin-top: 20vh;
-  width: 90%;
-}
-
-section p {
-  margin: 0 0 20px 40px;
+  .site-nav {
+    justify-content: flex-end;
+    font-size: 0.9rem;
+  }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -88,7 +88,7 @@ body {
 }
 
 .brand-text {
-  font-weight: 900;
+  font-weight: 700;
   letter-spacing: 0.08em;
 }
 
@@ -115,7 +115,6 @@ body {
 
 .visual-panel,
 .uniform-panel {
-  border: 1px solid var(--line);
   overflow: hidden;
 }
 
@@ -301,8 +300,6 @@ body {
 }
 
 .contact-banner {
-  border-top: 2px solid #ffc9b6;
-  border-bottom: 1px solid #ffd8c9;
   padding: 34px 0;
   text-align: left;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -1,13 +1,11 @@
 :root {
   --bg: #f7f8fb;
   --surface: #ffffff;
-  --surface-soft: #fdfdff;
-  --line: #e4e8f2;
+  --line: #e2e7f1;
   --text: #182038;
   --muted: #5d6887;
   --accent: #ff4d2d;
   --accent-strong: #ff7a00;
-  --shadow: 0 14px 32px rgba(22, 33, 68, 0.08);
   --max: 1140px;
 }
 
@@ -27,8 +25,8 @@ body {
 
 body {
   min-height: 100vh;
-  overflow-x: hidden;
   line-height: 1.7;
+  overflow-x: hidden;
 }
 
 .bg-shape {
@@ -44,7 +42,7 @@ body {
   height: 380px;
   top: -100px;
   left: -90px;
-  background: rgba(255, 120, 76, 0.26);
+  background: rgba(255, 120, 76, 0.24);
 }
 
 .bg-shape-2 {
@@ -52,7 +50,7 @@ body {
   height: 420px;
   right: -130px;
   top: 140px;
-  background: rgba(255, 161, 77, 0.22);
+  background: rgba(255, 161, 77, 0.2);
 }
 
 .container {
@@ -61,44 +59,31 @@ body {
 }
 
 .site-header {
-  width: min(var(--max), 96vw);
-  margin: 14px auto 0;
-  padding: 12px 18px;
+  width: min(var(--max), 100%);
+  margin: 0 auto;
+  padding: 12px 0;
   display: flex;
   align-items: center;
   justify-content: space-between;
+  border-bottom: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.88);
   position: sticky;
-  top: 10px;
-  z-index: 20;
-  border: 1px solid var(--line);
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.92);
-  backdrop-filter: blur(12px);
-  box-shadow: 0 10px 24px rgba(24, 32, 56, 0.06);
-}
-
-.site-header::before {
-  content: "";
-  position: absolute;
-  left: 0;
-  right: 0;
   top: 0;
-  height: 3px;
-  border-radius: 14px 14px 0 0;
-  background: linear-gradient(90deg, var(--accent), var(--accent-strong));
+  z-index: 20;
 }
 
 .brand {
   display: flex;
-  align-items: center;
   gap: 10px;
+  align-items: center;
   text-decoration: none;
   color: var(--text);
+  padding-left: 4vw;
 }
 
 .brand-logo {
-  width: 44px;
-  height: 44px;
+  width: 42px;
+  height: 42px;
   object-fit: contain;
 }
 
@@ -109,58 +94,55 @@ body {
 
 .site-nav {
   display: flex;
-  gap: 16px;
+  gap: 18px;
+  padding-right: 4vw;
 }
 
 .site-nav a {
   color: var(--muted);
   text-decoration: none;
-  font-size: 0.88rem;
+  font-size: 0.86rem;
   font-weight: 700;
-  position: relative;
-  padding-bottom: 4px;
-}
-
-.site-nav a::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  bottom: 0;
-  width: 100%;
-  height: 2px;
-  transform: scaleX(0);
-  transform-origin: right;
-  background: linear-gradient(90deg, var(--accent), var(--accent-strong));
-  transition: transform 0.2s ease;
 }
 
 .site-nav a:hover {
   color: var(--text);
 }
 
-.site-nav a:hover::after {
-  transform: scaleX(1);
-  transform-origin: left;
+.first-visual {
+  margin-top: 20px;
+}
+
+.visual-panel,
+.uniform-panel {
+  border: 1px solid var(--line);
+  overflow: hidden;
+}
+
+.visual-panel img,
+.uniform-panel img {
+  width: 100%;
+  display: block;
 }
 
 .hero {
-  padding-top: 74px;
+  padding-top: 44px;
 }
 
 .eyebrow,
 .section-kicker {
-  margin: 0 0 14px;
+  margin: 0 0 10px;
   display: inline-block;
-  letter-spacing: 0.15em;
   font-size: 0.74rem;
+  letter-spacing: 0.14em;
   font-weight: 700;
-  color: #7c869f;
+  color: #7b86a3;
 }
 
 .hero h1 {
   margin: 0;
-  font-size: clamp(2.3rem, 7vw, 5rem);
-  line-height: 1.12;
+  font-size: clamp(2rem, 6vw, 4.2rem);
+  line-height: 1.15;
   letter-spacing: -0.02em;
 }
 
@@ -172,17 +154,16 @@ body {
 }
 
 .hero-lead {
-  margin-top: 16px;
-  max-width: 700px;
+  margin-top: 14px;
+  max-width: 720px;
   color: var(--muted);
-  font-size: 1.02rem;
 }
 
 .hero-actions {
   display: flex;
   gap: 12px;
   flex-wrap: wrap;
-  margin-top: 24px;
+  margin-top: 22px;
 }
 
 .button-primary,
@@ -190,138 +171,99 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 999px;
-  padding: 12px 24px;
   text-decoration: none;
   font-weight: 800;
+  padding: 11px 22px;
 }
 
 .button-primary {
-  color: #fff;
   background: linear-gradient(135deg, var(--accent), var(--accent-strong));
-  box-shadow: 0 12px 24px rgba(255, 106, 44, 0.25);
+  color: #fff;
 }
 
 .button-ghost {
-  color: var(--text);
-  border: 1px solid #d9dfec;
+  border: 1px solid var(--line);
   background: #fff;
+  color: var(--text);
 }
 
 .hero-metrics {
-  margin: 30px 0 0;
+  margin: 28px 0 0;
   padding: 0;
   list-style: none;
   display: flex;
-  gap: 30px;
+  gap: 26px;
   flex-wrap: wrap;
 }
 
 .hero-metrics li {
   color: var(--muted);
-  font-weight: 500;
 }
 
 .hero-metrics span {
   display: block;
-  font-size: 1.48rem;
   font-weight: 900;
+  font-size: 1.4rem;
   line-height: 1.1;
   color: var(--text);
 }
 
-.visual-panel {
-  margin-top: 34px;
-  border-radius: 18px;
-  overflow: hidden;
-  border: 1px solid var(--line);
-  box-shadow: var(--shadow);
-  background: #fff;
-}
-
-.visual-panel img {
-  width: 100%;
-  display: block;
-}
-
 .section {
-  margin-top: 88px;
+  margin-top: 82px;
 }
 
 .section-heading h2,
 .section-heading h1 {
   margin: 0;
-  font-size: clamp(1.8rem, 4vw, 2.8rem);
-  letter-spacing: -0.01em;
+  font-size: clamp(1.7rem, 4vw, 2.6rem);
+}
+
+.plain-block {
+  margin-top: 16px;
+  padding: 22px 0;
+  border-top: 2px solid #ced7e8;
+  border-bottom: 1px solid #dbe1ee;
 }
 
 .about-grid {
-  margin-top: 18px;
   display: grid;
-  grid-template-columns: 1.4fr 1fr;
-  gap: 16px;
+  grid-template-columns: 1.5fr 1fr;
+  gap: 24px;
 }
 
-.card {
-  border-radius: 14px;
-  border: 1px solid var(--line);
-  background: var(--surface);
-  box-shadow: var(--shadow);
-  padding: 24px;
+.about-grid h3 {
+  margin: 0 0 8px;
+  font-size: 1.44rem;
 }
 
-.large-card {
-  position: relative;
-  background: linear-gradient(135deg, #ffffff 0%, #fff9f4 100%);
-}
-
-.large-card::before {
-  content: "";
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  width: 4px;
-  border-radius: 14px 0 0 14px;
-  background: linear-gradient(var(--accent), var(--accent-strong));
-}
-
-.large-card h3 {
-  margin: 0 0 10px;
-  font-size: 1.5rem;
-}
-
-.large-card p,
-.practice-card .meta,
-.privacy-card p,
-.contact-banner p {
+.about-grid p {
   margin: 0;
   color: var(--muted);
 }
 
-.info-list dl,
+.info-list,
 .info-list dt,
 .info-list dd {
   margin: 0;
 }
 
-.info-list dl {
+.info-list {
   display: grid;
-  gap: 14px;
+  gap: 12px;
 }
 
 .info-list div {
-  padding-bottom: 10px;
-  border-bottom: 1px dashed #d7deea;
+  padding-bottom: 8px;
+  border-bottom: 1px dashed #d8deea;
 }
 
 .info-list dt {
+  color: #7d87a5;
   font-size: 0.81rem;
-  color: #7d87a4;
 }
 
 .info-list dd {
-  margin-top: 4px;
+  margin-top: 3px;
   font-weight: 700;
 }
 
@@ -329,62 +271,59 @@ body {
   margin-top: 18px;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 16px;
+  gap: 22px;
 }
 
-.practice-card h3 {
+.practice-item {
+  padding-top: 14px;
+  border-top: 2px solid #d6deec;
+}
+
+.practice-item h3 {
   margin: 0;
-  font-size: 1.16rem;
+  font-size: 1.14rem;
 }
 
-.practice-card .meta {
-  margin: 8px 0 12px;
-  font-size: 0.94rem;
+.practice-item .meta {
+  margin: 6px 0 10px;
+  color: var(--muted);
+  font-size: 0.93rem;
 }
 
-.practice-card iframe {
+.practice-item iframe {
   width: 100%;
   height: 180px;
-  border: 0;
-  border-radius: 10px;
+  border: 1px solid var(--line);
 }
 
-.uniform-card {
+.uniform-panel {
   margin-top: 18px;
-  padding: 0;
-  overflow: hidden;
-}
-
-.uniform-card img {
-  width: 100%;
-  display: block;
 }
 
 .contact-banner {
-  text-align: center;
-  padding: 52px 24px;
-  border-radius: 16px;
-  border: 1px solid #ffd6c6;
-  background: linear-gradient(130deg, #fff4ee, #fff9f4);
+  border-top: 2px solid #ffc9b6;
+  border-bottom: 1px solid #ffd8c9;
+  padding: 34px 0;
+  text-align: left;
 }
 
 .contact-banner h2 {
   margin: 0;
-  font-size: clamp(1.7rem, 4vw, 2.7rem);
+  font-size: clamp(1.6rem, 4vw, 2.5rem);
 }
 
 .contact-banner p {
+  margin: 10px 0 20px;
+  color: var(--muted);
   max-width: 620px;
-  margin: 10px auto 24px;
 }
 
 .site-footer {
-  margin-top: 86px;
+  margin-top: 82px;
+  padding: 28px 4vw 36px;
   text-align: center;
-  padding: 32px 10px 42px;
   border-top: 1px solid var(--line);
   color: var(--muted);
-  background: rgba(255, 255, 255, 0.6);
 }
 
 .site-footer a {
@@ -399,11 +338,13 @@ body {
 }
 
 .privacy-main {
-  padding-top: 48px;
+  padding-top: 40px;
 }
 
-.privacy-card {
-  margin-top: 18px;
+.card {
+  margin-top: 16px;
+  padding: 20px 0;
+  border-top: 2px solid #ced7e8;
 }
 
 .privacy-card h2 {
@@ -411,29 +352,29 @@ body {
   font-size: 1.2rem;
 }
 
+.privacy-card p {
+  margin: 0;
+  color: var(--muted);
+}
+
 @media (max-width: 900px) {
   .site-header {
-    width: 92vw;
-    padding: 12px 14px;
-    flex-wrap: wrap;
-    gap: 8px;
+    display: block;
+    padding: 12px 4vw;
+  }
+
+  .brand,
+  .site-nav {
+    padding: 0;
   }
 
   .site-nav {
-    width: 100%;
+    margin-top: 8px;
     justify-content: space-between;
-  }
-
-  .hero {
-    padding-top: 44px;
   }
 
   .about-grid,
   .practice-grid {
     grid-template-columns: 1fr;
-  }
-
-  .hero-metrics {
-    gap: 18px;
   }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -1,14 +1,14 @@
 :root {
-  --bg: #f8f9fd;
-  --bg-accent: #eef2ff;
+  --bg: #f7f8fb;
   --surface: #ffffff;
-  --surface-soft: #f7f8fc;
-  --line: #dfe4f2;
-  --text: #1a2340;
-  --muted: #5e6788;
-  --accent: #ff4f7b;
-  --accent-2: #6f59ff;
-  --max: 1160px;
+  --surface-soft: #fdfdff;
+  --line: #e4e8f2;
+  --text: #182038;
+  --muted: #5d6887;
+  --accent: #ff4d2d;
+  --accent-strong: #ff7a00;
+  --shadow: 0 14px 32px rgba(22, 33, 68, 0.08);
+  --max: 1140px;
 }
 
 * {
@@ -20,40 +20,39 @@ body {
   margin: 0;
   padding: 0;
   font-family: "Noto Sans JP", "Hiragino Kaku Gothic ProN", Meiryo, sans-serif;
-  background: var(--bg);
   color: var(--text);
+  background: linear-gradient(180deg, #fbfcff 0%, #f6f8fc 100%);
   scroll-behavior: smooth;
 }
 
 body {
   min-height: 100vh;
-  line-height: 1.7;
-  position: relative;
   overflow-x: hidden;
+  line-height: 1.7;
 }
 
 .bg-shape {
   position: fixed;
   border-radius: 999px;
-  filter: blur(70px);
-  z-index: -1;
+  filter: blur(80px);
   pointer-events: none;
+  z-index: -1;
 }
 
 .bg-shape-1 {
-  width: 420px;
-  height: 420px;
-  top: -120px;
-  left: -120px;
-  background: #ffc6d7;
+  width: 380px;
+  height: 380px;
+  top: -100px;
+  left: -90px;
+  background: rgba(255, 120, 76, 0.26);
 }
 
 .bg-shape-2 {
-  width: 500px;
-  height: 500px;
-  right: -180px;
-  top: 200px;
-  background: #d8d0ff;
+  width: 420px;
+  height: 420px;
+  right: -130px;
+  top: 140px;
+  background: rgba(255, 161, 77, 0.22);
 }
 
 .container {
@@ -63,37 +62,49 @@ body {
 
 .site-header {
   width: min(var(--max), 96vw);
-  margin: 18px auto 0;
-  padding: 14px 20px;
+  margin: 14px auto 0;
+  padding: 12px 18px;
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  justify-content: space-between;
   position: sticky;
-  top: 12px;
+  top: 10px;
   z-index: 20;
-  background: rgba(255, 255, 255, 0.82);
   border: 1px solid var(--line);
-  border-radius: 16px;
-  backdrop-filter: blur(18px);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 10px 24px rgba(24, 32, 56, 0.06);
+}
+
+.site-header::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 3px;
+  border-radius: 14px 14px 0 0;
+  background: linear-gradient(90deg, var(--accent), var(--accent-strong));
 }
 
 .brand {
   display: flex;
-  gap: 10px;
   align-items: center;
+  gap: 10px;
   text-decoration: none;
   color: var(--text);
 }
 
 .brand-logo {
-  width: 46px;
-  height: 46px;
+  width: 44px;
+  height: 44px;
   object-fit: contain;
 }
 
 .brand-text {
   font-weight: 900;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.08em;
 }
 
 .site-nav {
@@ -102,38 +113,59 @@ body {
 }
 
 .site-nav a {
-  text-decoration: none;
   color: var(--muted);
-  font-size: 0.9rem;
-  font-weight: 500;
+  text-decoration: none;
+  font-size: 0.88rem;
+  font-weight: 700;
+  position: relative;
+  padding-bottom: 4px;
+}
+
+.site-nav a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 2px;
+  transform: scaleX(0);
+  transform-origin: right;
+  background: linear-gradient(90deg, var(--accent), var(--accent-strong));
+  transition: transform 0.2s ease;
 }
 
 .site-nav a:hover {
   color: var(--text);
 }
 
+.site-nav a:hover::after {
+  transform: scaleX(1);
+  transform-origin: left;
+}
+
 .hero {
-  padding-top: 70px;
+  padding-top: 74px;
 }
 
 .eyebrow,
 .section-kicker {
   margin: 0 0 14px;
   display: inline-block;
-  letter-spacing: 0.14em;
-  font-size: 0.75rem;
-  color: #7a83a6;
+  letter-spacing: 0.15em;
+  font-size: 0.74rem;
+  font-weight: 700;
+  color: #7c869f;
 }
 
 .hero h1 {
   margin: 0;
-  line-height: 1.2;
-  font-size: clamp(2rem, 7vw, 4.4rem);
-  font-weight: 900;
+  font-size: clamp(2.3rem, 7vw, 5rem);
+  line-height: 1.12;
+  letter-spacing: -0.02em;
 }
 
 .hero h1 span {
-  background: linear-gradient(120deg, var(--accent), var(--accent-2));
+  background: linear-gradient(125deg, var(--accent), var(--accent-strong));
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
@@ -141,13 +173,14 @@ body {
 
 .hero-lead {
   margin-top: 16px;
-  max-width: 720px;
+  max-width: 700px;
   color: var(--muted);
+  font-size: 1.02rem;
 }
 
 .hero-actions {
   display: flex;
-  gap: 14px;
+  gap: 12px;
   flex-wrap: wrap;
   margin-top: 24px;
 }
@@ -158,25 +191,25 @@ body {
   align-items: center;
   justify-content: center;
   border-radius: 999px;
-  text-decoration: none;
-  font-weight: 700;
   padding: 12px 24px;
+  text-decoration: none;
+  font-weight: 800;
 }
 
 .button-primary {
   color: #fff;
-  background: linear-gradient(130deg, var(--accent), var(--accent-2));
-  box-shadow: 0 10px 24px rgba(141, 93, 255, 0.25);
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  box-shadow: 0 12px 24px rgba(255, 106, 44, 0.25);
 }
 
 .button-ghost {
   color: var(--text);
-  border: 1px solid var(--line);
-  background: #ffffff;
+  border: 1px solid #d9dfec;
+  background: #fff;
 }
 
 .hero-metrics {
-  margin: 28px 0 0;
+  margin: 30px 0 0;
   padding: 0;
   list-style: none;
   display: flex;
@@ -186,23 +219,24 @@ body {
 
 .hero-metrics li {
   color: var(--muted);
+  font-weight: 500;
 }
 
 .hero-metrics span {
   display: block;
-  color: var(--text);
+  font-size: 1.48rem;
   font-weight: 900;
-  font-size: 1.5rem;
   line-height: 1.1;
+  color: var(--text);
 }
 
 .visual-panel {
   margin-top: 34px;
-  border-radius: 24px;
+  border-radius: 18px;
   overflow: hidden;
   border: 1px solid var(--line);
+  box-shadow: var(--shadow);
   background: #fff;
-  box-shadow: 0 20px 40px rgba(34, 52, 118, 0.12);
 }
 
 .visual-panel img {
@@ -211,39 +245,56 @@ body {
 }
 
 .section {
-  margin-top: 96px;
+  margin-top: 88px;
 }
 
 .section-heading h2,
 .section-heading h1 {
   margin: 0;
   font-size: clamp(1.8rem, 4vw, 2.8rem);
+  letter-spacing: -0.01em;
 }
 
 .about-grid {
   margin-top: 18px;
   display: grid;
-  grid-template-columns: 1.5fr 1fr;
+  grid-template-columns: 1.4fr 1fr;
   gap: 16px;
 }
 
 .card {
-  border-radius: 20px;
+  border-radius: 14px;
   border: 1px solid var(--line);
   background: var(--surface);
+  box-shadow: var(--shadow);
   padding: 24px;
-  box-shadow: 0 10px 26px rgba(44, 62, 128, 0.08);
+}
+
+.large-card {
+  position: relative;
+  background: linear-gradient(135deg, #ffffff 0%, #fff9f4 100%);
+}
+
+.large-card::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+  border-radius: 14px 0 0 14px;
+  background: linear-gradient(var(--accent), var(--accent-strong));
 }
 
 .large-card h3 {
   margin: 0 0 10px;
-  font-size: 1.6rem;
+  font-size: 1.5rem;
 }
 
 .large-card p,
+.practice-card .meta,
 .privacy-card p,
-.contact-banner p,
-.practice-card .meta {
+.contact-banner p {
   margin: 0;
   color: var(--muted);
 }
@@ -260,13 +311,13 @@ body {
 }
 
 .info-list div {
-  border-bottom: 1px dashed var(--line);
   padding-bottom: 10px;
+  border-bottom: 1px dashed #d7deea;
 }
 
 .info-list dt {
-  color: #7b84a7;
-  font-size: 0.82rem;
+  font-size: 0.81rem;
+  color: #7d87a4;
 }
 
 .info-list dd {
@@ -283,19 +334,19 @@ body {
 
 .practice-card h3 {
   margin: 0;
-  font-size: 1.2rem;
+  font-size: 1.16rem;
 }
 
 .practice-card .meta {
-  margin: 6px 0 12px;
-  font-size: 0.95rem;
+  margin: 8px 0 12px;
+  font-size: 0.94rem;
 }
 
 .practice-card iframe {
   width: 100%;
   height: 180px;
   border: 0;
-  border-radius: 12px;
+  border-radius: 10px;
 }
 
 .uniform-card {
@@ -311,15 +362,15 @@ body {
 
 .contact-banner {
   text-align: center;
-  padding: 54px 24px;
-  border-radius: 26px;
-  border: 1px solid #e5d8ff;
-  background: linear-gradient(145deg, #fff3f7, #f2eeff);
+  padding: 52px 24px;
+  border-radius: 16px;
+  border: 1px solid #ffd6c6;
+  background: linear-gradient(130deg, #fff4ee, #fff9f4);
 }
 
 .contact-banner h2 {
   margin: 0;
-  font-size: clamp(1.7rem, 4vw, 2.8rem);
+  font-size: clamp(1.7rem, 4vw, 2.7rem);
 }
 
 .contact-banner p {
@@ -328,12 +379,12 @@ body {
 }
 
 .site-footer {
-  margin-top: 90px;
-  padding: 34px 10px 42px;
+  margin-top: 86px;
   text-align: center;
+  padding: 32px 10px 42px;
   border-top: 1px solid var(--line);
   color: var(--muted);
-  background: rgba(255, 255, 255, 0.5);
+  background: rgba(255, 255, 255, 0.6);
 }
 
 .site-footer a {
@@ -344,6 +395,7 @@ body {
 .page-top {
   display: inline-block;
   margin-bottom: 8px;
+  font-weight: 700;
 }
 
 .privacy-main {
@@ -362,10 +414,9 @@ body {
 @media (max-width: 900px) {
   .site-header {
     width: 92vw;
-    top: 8px;
     padding: 12px 14px;
-    gap: 8px;
     flex-wrap: wrap;
+    gap: 8px;
   }
 
   .site-nav {
@@ -374,7 +425,7 @@ body {
   }
 
   .hero {
-    padding-top: 42px;
+    padding-top: 44px;
   }
 
   .about-grid,

--- a/css/style.css
+++ b/css/style.css
@@ -1,12 +1,13 @@
 :root {
-  --bg: #05060c;
-  --surface: #0d1222;
-  --surface-strong: #121a31;
-  --line: rgba(255, 255, 255, 0.15);
-  --text: #eef2ff;
-  --muted: #b6c1df;
+  --bg: #f8f9fd;
+  --bg-accent: #eef2ff;
+  --surface: #ffffff;
+  --surface-soft: #f7f8fc;
+  --line: #dfe4f2;
+  --text: #1a2340;
+  --muted: #5e6788;
   --accent: #ff4f7b;
-  --accent-2: #7f63ff;
+  --accent-2: #6f59ff;
   --max: 1160px;
 }
 
@@ -19,50 +20,40 @@ body {
   margin: 0;
   padding: 0;
   font-family: "Noto Sans JP", "Hiragino Kaku Gothic ProN", Meiryo, sans-serif;
-  color: var(--text);
   background: var(--bg);
+  color: var(--text);
   scroll-behavior: smooth;
 }
 
 body {
   min-height: 100vh;
-  position: relative;
   line-height: 1.7;
+  position: relative;
   overflow-x: hidden;
 }
 
-.noise {
-  position: fixed;
-  inset: 0;
-  background-image: radial-gradient(rgba(255, 255, 255, 0.05) 0.6px, transparent 0.6px);
-  background-size: 2px 2px;
-  opacity: 0.3;
-  pointer-events: none;
-  z-index: -1;
-}
-
-.aurora {
+.bg-shape {
   position: fixed;
   border-radius: 999px;
-  filter: blur(60px);
-  z-index: -2;
+  filter: blur(70px);
+  z-index: -1;
   pointer-events: none;
 }
 
-.aurora-1 {
+.bg-shape-1 {
   width: 420px;
   height: 420px;
-  top: -90px;
-  left: -110px;
-  background: #ff4f7b80;
+  top: -120px;
+  left: -120px;
+  background: #ffc6d7;
 }
 
-.aurora-2 {
-  width: 480px;
-  height: 480px;
-  right: -120px;
-  top: 220px;
-  background: #7f63ff66;
+.bg-shape-2 {
+  width: 500px;
+  height: 500px;
+  right: -180px;
+  top: 200px;
+  background: #d8d0ff;
 }
 
 .container {
@@ -80,18 +71,18 @@ body {
   position: sticky;
   top: 12px;
   z-index: 20;
-  background: rgba(8, 12, 24, 0.72);
+  background: rgba(255, 255, 255, 0.82);
   border: 1px solid var(--line);
   border-radius: 16px;
   backdrop-filter: blur(18px);
 }
 
 .brand {
-  text-decoration: none;
-  color: var(--text);
   display: flex;
   gap: 10px;
   align-items: center;
+  text-decoration: none;
+  color: var(--text);
 }
 
 .brand-logo {
@@ -114,11 +105,11 @@ body {
   text-decoration: none;
   color: var(--muted);
   font-size: 0.9rem;
-  transition: color 0.2s ease;
+  font-weight: 500;
 }
 
 .site-nav a:hover {
-  color: #fff;
+  color: var(--text);
 }
 
 .hero {
@@ -127,17 +118,17 @@ body {
 
 .eyebrow,
 .section-kicker {
-  display: inline-block;
-  letter-spacing: 0.18em;
-  font-size: 0.72rem;
-  color: #d8dfff;
   margin: 0 0 14px;
+  display: inline-block;
+  letter-spacing: 0.14em;
+  font-size: 0.75rem;
+  color: #7a83a6;
 }
 
 .hero h1 {
   margin: 0;
-  line-height: 1.15;
-  font-size: clamp(2.2rem, 7vw, 5rem);
+  line-height: 1.2;
+  font-size: clamp(2rem, 7vw, 4.4rem);
   font-weight: 900;
 }
 
@@ -150,7 +141,7 @@ body {
 
 .hero-lead {
   margin-top: 16px;
-  max-width: 700px;
+  max-width: 720px;
   color: var(--muted);
 }
 
@@ -173,21 +164,21 @@ body {
 }
 
 .button-primary {
-  background: linear-gradient(130deg, var(--accent), var(--accent-2));
   color: #fff;
-  box-shadow: 0 14px 28px rgba(123, 86, 255, 0.4);
+  background: linear-gradient(130deg, var(--accent), var(--accent-2));
+  box-shadow: 0 10px 24px rgba(141, 93, 255, 0.25);
 }
 
 .button-ghost {
-  border: 1px solid var(--line);
   color: var(--text);
-  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--line);
+  background: #ffffff;
 }
 
 .hero-metrics {
-  list-style: none;
   margin: 28px 0 0;
   padding: 0;
+  list-style: none;
   display: flex;
   gap: 30px;
   flex-wrap: wrap;
@@ -199,10 +190,10 @@ body {
 
 .hero-metrics span {
   display: block;
-  color: #fff;
-  font-size: 1.7rem;
+  color: var(--text);
   font-weight: 900;
-  line-height: 1;
+  font-size: 1.5rem;
+  line-height: 1.1;
 }
 
 .visual-panel {
@@ -210,7 +201,8 @@ body {
   border-radius: 24px;
   overflow: hidden;
   border: 1px solid var(--line);
-  box-shadow: 0 30px 50px rgba(0, 0, 0, 0.4);
+  background: #fff;
+  box-shadow: 0 20px 40px rgba(34, 52, 118, 0.12);
 }
 
 .visual-panel img {
@@ -225,7 +217,7 @@ body {
 .section-heading h2,
 .section-heading h1 {
   margin: 0;
-  font-size: clamp(1.8rem, 4vw, 2.9rem);
+  font-size: clamp(1.8rem, 4vw, 2.8rem);
 }
 
 .about-grid {
@@ -238,8 +230,9 @@ body {
 .card {
   border-radius: 20px;
   border: 1px solid var(--line);
-  background: linear-gradient(145deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.03));
+  background: var(--surface);
   padding: 24px;
+  box-shadow: 0 10px 26px rgba(44, 62, 128, 0.08);
 }
 
 .large-card h3 {
@@ -247,7 +240,10 @@ body {
   font-size: 1.6rem;
 }
 
-.large-card p {
+.large-card p,
+.privacy-card p,
+.contact-banner p,
+.practice-card .meta {
   margin: 0;
   color: var(--muted);
 }
@@ -264,12 +260,12 @@ body {
 }
 
 .info-list div {
-  border-bottom: 1px dashed rgba(255, 255, 255, 0.2);
+  border-bottom: 1px dashed var(--line);
   padding-bottom: 10px;
 }
 
 .info-list dt {
-  color: #d3dcfb;
+  color: #7b84a7;
   font-size: 0.82rem;
 }
 
@@ -292,7 +288,6 @@ body {
 
 .practice-card .meta {
   margin: 6px 0 12px;
-  color: var(--muted);
   font-size: 0.95rem;
 }
 
@@ -317,9 +312,9 @@ body {
 .contact-banner {
   text-align: center;
   padding: 54px 24px;
-  background: linear-gradient(145deg, rgba(255, 79, 123, 0.25), rgba(127, 99, 255, 0.22));
   border-radius: 26px;
-  border: 1px solid rgba(255, 255, 255, 0.25);
+  border: 1px solid #e5d8ff;
+  background: linear-gradient(145deg, #fff3f7, #f2eeff);
 }
 
 .contact-banner h2 {
@@ -328,21 +323,21 @@ body {
 }
 
 .contact-banner p {
-  color: var(--muted);
   max-width: 620px;
   margin: 10px auto 24px;
 }
 
 .site-footer {
   margin-top: 90px;
-  text-align: center;
   padding: 34px 10px 42px;
+  text-align: center;
   border-top: 1px solid var(--line);
   color: var(--muted);
+  background: rgba(255, 255, 255, 0.5);
 }
 
 .site-footer a {
-  color: #fff;
+  color: var(--text);
   text-decoration: none;
 }
 
@@ -364,18 +359,13 @@ body {
   font-size: 1.2rem;
 }
 
-.privacy-card p {
-  margin: 0;
-  color: var(--muted);
-}
-
 @media (max-width: 900px) {
   .site-header {
     width: 92vw;
     top: 8px;
     padding: 12px 14px;
-    flex-wrap: wrap;
     gap: 8px;
+    flex-wrap: wrap;
   }
 
   .site-nav {

--- a/css/style.css
+++ b/css/style.css
@@ -1,13 +1,13 @@
 :root {
-  --bg: #06070d;
-  --bg-soft: #121528;
-  --text: #f2f5ff;
-  --muted: #b7c0de;
-  --accent: #ff335f;
-  --accent-2: #8c52ff;
-  --glass: rgba(255, 255, 255, 0.08);
-  --glass-border: rgba(255, 255, 255, 0.22);
-  --shadow: 0 20px 40px rgba(3, 8, 30, 0.45);
+  --bg: #05060c;
+  --surface: #0d1222;
+  --surface-strong: #121a31;
+  --line: rgba(255, 255, 255, 0.15);
+  --text: #eef2ff;
+  --muted: #b6c1df;
+  --accent: #ff4f7b;
+  --accent-2: #7f63ff;
+  --max: 1160px;
 }
 
 * {
@@ -19,50 +19,84 @@ body {
   margin: 0;
   padding: 0;
   font-family: "Noto Sans JP", "Hiragino Kaku Gothic ProN", Meiryo, sans-serif;
-  background: var(--bg);
   color: var(--text);
+  background: var(--bg);
   scroll-behavior: smooth;
 }
 
 body {
   min-height: 100vh;
+  position: relative;
   line-height: 1.7;
+  overflow-x: hidden;
 }
 
-.bg-layer {
+.noise {
   position: fixed;
   inset: 0;
-  background: radial-gradient(circle at 10% 20%, #ff335f33, transparent 35%),
-    radial-gradient(circle at 80% 10%, #8c52ff44, transparent 32%),
-    radial-gradient(circle at 60% 80%, #ffffff20, transparent 28%),
-    linear-gradient(145deg, #070a14 10%, #090f23 60%, #0f1224 100%);
+  background-image: radial-gradient(rgba(255, 255, 255, 0.05) 0.6px, transparent 0.6px);
+  background-size: 2px 2px;
+  opacity: 0.3;
+  pointer-events: none;
   z-index: -1;
 }
 
+.aurora {
+  position: fixed;
+  border-radius: 999px;
+  filter: blur(60px);
+  z-index: -2;
+  pointer-events: none;
+}
+
+.aurora-1 {
+  width: 420px;
+  height: 420px;
+  top: -90px;
+  left: -110px;
+  background: #ff4f7b80;
+}
+
+.aurora-2 {
+  width: 480px;
+  height: 480px;
+  right: -120px;
+  top: 220px;
+  background: #7f63ff66;
+}
+
+.container {
+  width: min(var(--max), 92vw);
+  margin: 0 auto;
+}
+
 .site-header {
-  position: sticky;
-  top: 0;
-  z-index: 10;
+  width: min(var(--max), 96vw);
+  margin: 18px auto 0;
+  padding: 14px 20px;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 12px 5vw;
-  backdrop-filter: blur(14px);
-  background: rgba(6, 7, 13, 0.5);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  position: sticky;
+  top: 12px;
+  z-index: 20;
+  background: rgba(8, 12, 24, 0.72);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  backdrop-filter: blur(18px);
 }
 
 .brand {
+  text-decoration: none;
+  color: var(--text);
   display: flex;
   gap: 10px;
   align-items: center;
-  text-decoration: none;
-  color: var(--text);
 }
 
 .brand-logo {
-  width: 52px;
-  height: 52px;
+  width: 46px;
+  height: 46px;
   object-fit: contain;
 }
 
@@ -73,14 +107,13 @@ body {
 
 .site-nav {
   display: flex;
-  gap: 18px;
-  flex-wrap: wrap;
+  gap: 16px;
 }
 
 .site-nav a {
-  color: var(--muted);
   text-decoration: none;
-  font-weight: 500;
+  color: var(--muted);
+  font-size: 0.9rem;
   transition: color 0.2s ease;
 }
 
@@ -88,122 +121,190 @@ body {
   color: #fff;
 }
 
-main {
-  width: min(1140px, 92vw);
-  margin: 0 auto;
-}
-
 .hero {
-  min-height: 80vh;
-  display: grid;
-  grid-template-columns: 1.1fr 1fr;
-  align-items: center;
-  gap: 28px;
-  padding: 60px 0 30px;
+  padding-top: 70px;
 }
 
-.badge {
+.eyebrow,
+.section-kicker {
   display: inline-block;
-  margin-bottom: 18px;
-  padding: 6px 14px;
-  border-radius: 999px;
-  font-size: 0.8rem;
-  color: #ffe7ee;
-  background: linear-gradient(90deg, #ff335faa, #8c52ffaa);
+  letter-spacing: 0.18em;
+  font-size: 0.72rem;
+  color: #d8dfff;
+  margin: 0 0 14px;
 }
 
 .hero h1 {
-  font-size: clamp(2rem, 5vw, 3.4rem);
-  line-height: 1.2;
   margin: 0;
+  line-height: 1.15;
+  font-size: clamp(2.2rem, 7vw, 5rem);
+  font-weight: 900;
 }
 
 .hero h1 span {
-  background: linear-gradient(90deg, #ff4d79, #9f69ff);
+  background: linear-gradient(120deg, var(--accent), var(--accent-2));
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
 }
 
-.hero p {
+.hero-lead {
+  margin-top: 16px;
+  max-width: 700px;
   color: var(--muted);
 }
 
-.hero-image-wrap {
-  border-radius: 26px;
-  overflow: hidden;
-  border: 1px solid var(--glass-border);
-  box-shadow: var(--shadow);
+.hero-actions {
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+  margin-top: 24px;
 }
 
-.hero-image {
-  width: 100%;
-  height: 100%;
+.button-primary,
+.button-ghost {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 700;
+  padding: 12px 24px;
+}
+
+.button-primary {
+  background: linear-gradient(130deg, var(--accent), var(--accent-2));
+  color: #fff;
+  box-shadow: 0 14px 28px rgba(123, 86, 255, 0.4);
+}
+
+.button-ghost {
+  border: 1px solid var(--line);
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.hero-metrics {
+  list-style: none;
+  margin: 28px 0 0;
+  padding: 0;
+  display: flex;
+  gap: 30px;
+  flex-wrap: wrap;
+}
+
+.hero-metrics li {
+  color: var(--muted);
+}
+
+.hero-metrics span {
   display: block;
-  object-fit: cover;
+  color: #fff;
+  font-size: 1.7rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.visual-panel {
+  margin-top: 34px;
+  border-radius: 24px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  box-shadow: 0 30px 50px rgba(0, 0, 0, 0.4);
+}
+
+.visual-panel img {
+  width: 100%;
+  display: block;
 }
 
 .section {
-  margin-top: 72px;
+  margin-top: 96px;
 }
 
-.section-title {
-  margin: 0 0 18px;
-  font-size: clamp(1.5rem, 3vw, 2.1rem);
-}
-
-.glass-card {
-  background: var(--glass);
-  border: 1px solid var(--glass-border);
-  border-radius: 20px;
-  padding: 24px;
-  box-shadow: var(--shadow);
-}
-
-.stats-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 18px;
-}
-
-.label {
+.section-heading h2,
+.section-heading h1 {
   margin: 0;
-  font-size: 0.82rem;
-  color: #d3daf4;
+  font-size: clamp(1.8rem, 4vw, 2.9rem);
 }
 
-.value {
-  margin: 6px 0 0;
-  font-size: 1.05rem;
-  font-weight: 700;
-  color: #fff;
-}
-
-.practice-grid {
+.about-grid {
+  margin-top: 18px;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 18px;
+  grid-template-columns: 1.5fr 1fr;
+  gap: 16px;
 }
 
-.practice-card h3 {
-  margin: 0 0 8px;
-  font-size: 1.15rem;
+.card {
+  border-radius: 20px;
+  border: 1px solid var(--line);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.03));
+  padding: 24px;
 }
 
-.practice-card p {
-  margin: 4px 0;
+.large-card h3 {
+  margin: 0 0 10px;
+  font-size: 1.6rem;
+}
+
+.large-card p {
+  margin: 0;
   color: var(--muted);
 }
 
+.info-list dl,
+.info-list dt,
+.info-list dd {
+  margin: 0;
+}
+
+.info-list dl {
+  display: grid;
+  gap: 14px;
+}
+
+.info-list div {
+  border-bottom: 1px dashed rgba(255, 255, 255, 0.2);
+  padding-bottom: 10px;
+}
+
+.info-list dt {
+  color: #d3dcfb;
+  font-size: 0.82rem;
+}
+
+.info-list dd {
+  margin-top: 4px;
+  font-weight: 700;
+}
+
+.practice-grid {
+  margin-top: 18px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.practice-card h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.practice-card .meta {
+  margin: 6px 0 12px;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
 .practice-card iframe {
-  margin-top: 12px;
   width: 100%;
-  height: 170px;
+  height: 180px;
   border: 0;
   border-radius: 12px;
 }
 
 .uniform-card {
+  margin-top: 18px;
   padding: 0;
   overflow: hidden;
 }
@@ -213,45 +314,30 @@ main {
   display: block;
 }
 
-.contact-card {
+.contact-banner {
   text-align: center;
-  padding: 42px 24px;
-  border-radius: 24px;
-  background: linear-gradient(140deg, #ff335fdd, #8c52ffdd);
-  box-shadow: var(--shadow);
+  padding: 54px 24px;
+  background: linear-gradient(145deg, rgba(255, 79, 123, 0.25), rgba(127, 99, 255, 0.22));
+  border-radius: 26px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
 }
 
-.contact-card h2 {
+.contact-banner h2 {
   margin: 0;
-  font-size: clamp(1.4rem, 2.8vw, 2rem);
+  font-size: clamp(1.7rem, 4vw, 2.8rem);
 }
 
-.contact-card p {
-  color: #fff;
-  margin: 12px 0 24px;
-}
-
-.cta-button {
-  display: inline-block;
-  text-decoration: none;
-  font-weight: 700;
-  color: #101222;
-  background: #fff;
-  padding: 12px 22px;
-  border-radius: 999px;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.cta-button:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 24px rgba(255, 255, 255, 0.25);
+.contact-banner p {
+  color: var(--muted);
+  max-width: 620px;
+  margin: 10px auto 24px;
 }
 
 .site-footer {
-  margin-top: 80px;
-  padding: 28px 4vw 36px;
-  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  margin-top: 90px;
   text-align: center;
+  padding: 34px 10px 42px;
+  border-top: 1px solid var(--line);
   color: var(--muted);
 }
 
@@ -262,16 +348,20 @@ main {
 
 .page-top {
   display: inline-block;
-  margin-bottom: 12px;
+  margin-bottom: 8px;
 }
 
-.privacy-section {
+.privacy-main {
   padding-top: 48px;
 }
 
+.privacy-card {
+  margin-top: 18px;
+}
+
 .privacy-card h2 {
-  margin: 24px 0 8px;
-  font-size: 1.1rem;
+  margin: 24px 0 6px;
+  font-size: 1.2rem;
 }
 
 .privacy-card p {
@@ -280,19 +370,29 @@ main {
 }
 
 @media (max-width: 900px) {
-  .hero {
-    grid-template-columns: 1fr;
-    min-height: auto;
-    padding-top: 30px;
-  }
-
   .site-header {
-    position: static;
-    gap: 10px;
+    width: 92vw;
+    top: 8px;
+    padding: 12px 14px;
+    flex-wrap: wrap;
+    gap: 8px;
   }
 
   .site-nav {
-    justify-content: flex-end;
-    font-size: 0.9rem;
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .hero {
+    padding-top: 42px;
+  }
+
+  .about-grid,
+  .practice-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-metrics {
+    gap: 18px;
   }
 }

--- a/index.html
+++ b/index.html
@@ -32,9 +32,8 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon.ico" />
   </head>
   <body>
-    <div class="noise"></div>
-    <div class="aurora aurora-1"></div>
-    <div class="aurora aurora-2"></div>
+    <div class="bg-shape bg-shape-1"></div>
+    <div class="bg-shape bg-shape-2"></div>
 
     <header class="site-header" id="top">
       <a href="#top" class="brand">
@@ -42,23 +41,24 @@
         <span class="brand-text">BLAZE</span>
       </a>
       <nav class="site-nav" aria-label="メインナビゲーション">
-        <a href="#about">About</a>
-        <a href="#practice">Practice</a>
-        <a href="#uniform">Uniform</a>
-        <a href="#contact">Contact</a>
+        <a href="#about">クラブ紹介</a>
+        <a href="#practice">練習情報</a>
+        <a href="#uniform">ユニフォーム</a>
+        <a href="#contact">参加方法</a>
       </nav>
     </header>
 
     <main class="container">
       <section class="hero">
-        <p class="eyebrow">HAMADA CITY TABLE TENNIS CLUB</p>
+        <p class="eyebrow">浜田市卓球クラブ BLAZE</p>
         <h1>
-          Play with <span>Heat</span>,<br />
-          Grow with <span>Style</span>.
+          強く、楽しく、
+          <span>誇れる卓球を。</span>
         </h1>
         <p class="hero-lead">
-          浜田市を拠点に、競技志向と楽しさを両立する卓球クラブ。
-          一人ひとりの挑戦をチームで支え、次のレベルへ進む場をつくります。
+          Blazeは浜田市を拠点に活動する卓球クラブです。
+          競技志向とコミュニティの温かさを両立し、
+          一人ひとりが成長できる環境づくりを大切にしています。
         </p>
         <div class="hero-actions">
           <a href="mailto:blaze.hamada2018@gmail.com" class="button-primary"
@@ -68,8 +68,8 @@
         </div>
         <ul class="hero-metrics">
           <li><span>2018</span>創立</li>
-          <li><span>14</span>メンバー</li>
-          <li><span>4</span>練習拠点</li>
+          <li><span>14名</span>メンバー</li>
+          <li><span>4拠点</span>練習場所</li>
         </ul>
       </section>
 
@@ -79,16 +79,16 @@
 
       <section class="section" id="about">
         <div class="section-heading">
-          <p class="section-kicker">ABOUT BLAZE</p>
+          <p class="section-kicker">クラブ情報</p>
           <h2>クラブ紹介</h2>
         </div>
         <div class="about-grid">
           <article class="card large-card">
             <h3>競技力とコミュニティの両立</h3>
             <p>
-              Blazeは経験者を中心に、より高いレベルを目指して練習しています。
-              同時に、初心者やブランクのある方にも安心して参加いただける
-              オープンな雰囲気を大切にしています。
+              経験者を中心に、より高いレベルを目指して練習しています。
+              同時に、初心者やブランクのある方でも参加しやすい、
+              オープンな雰囲気づくりを大切にしています。
             </p>
           </article>
           <article class="card info-list">
@@ -104,7 +104,7 @@
 
       <section class="section" id="practice">
         <div class="section-heading">
-          <p class="section-kicker">PRACTICE SCHEDULE</p>
+          <p class="section-kicker">練習スケジュール</p>
           <h2>練習情報</h2>
         </div>
         <div class="practice-grid">
@@ -156,7 +156,7 @@
 
       <section class="section" id="uniform">
         <div class="section-heading">
-          <p class="section-kicker">TEAM STYLE</p>
+          <p class="section-kicker">チームスタイル</p>
           <h2>チームユニフォーム</h2>
         </div>
         <article class="card uniform-card">
@@ -166,11 +166,11 @@
 
       <section class="section" id="contact">
         <article class="contact-banner">
-          <p class="section-kicker">JOIN US</p>
+          <p class="section-kicker">参加受付中</p>
           <h2>見学・体験参加を受付中</h2>
           <p>
-            卓球が上手くなりたい、仲間と真剣に取り組みたい方へ。
-            まずは気軽にご連絡ください。
+            卓球がもっと上手くなりたい方、仲間と真剣に取り組みたい方へ。
+            まずはお気軽にご連絡ください。
           </p>
           <a href="mailto:blaze.hamada2018@gmail.com" class="button-primary"
             >練習参加希望はこちら</a
@@ -180,7 +180,7 @@
     </main>
 
     <footer class="site-footer">
-      <a href="#top" class="page-top">Page Top</a>
+      <a href="#top" class="page-top">ページトップへ</a>
       <p>
         <a href="./privacy.html">Copyright &copy; 2023 BLAZE All rights reserved.</a>
       </p>

--- a/index.html
+++ b/index.html
@@ -32,74 +32,85 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon.ico" />
   </head>
   <body>
-    <div class="bg-layer"></div>
+    <div class="noise"></div>
+    <div class="aurora aurora-1"></div>
+    <div class="aurora aurora-2"></div>
 
-    <header class="site-header">
-      <a href="#top" class="brand" id="top">
+    <header class="site-header" id="top">
+      <a href="#top" class="brand">
         <img src="./img/blaze_logo.png" alt="Blazeロゴ" class="brand-logo" />
         <span class="brand-text">BLAZE</span>
       </a>
       <nav class="site-nav" aria-label="メインナビゲーション">
-        <a href="#about">クラブ紹介</a>
-        <a href="#practice">練習情報</a>
-        <a href="#uniform">ユニフォーム</a>
-        <a href="#contact">参加方法</a>
+        <a href="#about">About</a>
+        <a href="#practice">Practice</a>
+        <a href="#uniform">Uniform</a>
+        <a href="#contact">Contact</a>
       </nav>
     </header>
 
-    <main>
+    <main class="container">
       <section class="hero">
-        <div class="hero-content">
-          <p class="badge">Shimane Hamada Table Tennis Club</p>
-          <h1>熱く、楽しく、
-            <span>本気で卓球。</span>
-          </h1>
-          <p>
-            Blazeは、浜田市を拠点に活動する卓球クラブです。経験者はもちろん、
-            向上心のある方を歓迎しています。
-          </p>
-          <a href="mailto:blaze.hamada2018@gmail.com" class="cta-button"
+        <p class="eyebrow">HAMADA CITY TABLE TENNIS CLUB</p>
+        <h1>
+          Play with <span>Heat</span>,<br />
+          Grow with <span>Style</span>.
+        </h1>
+        <p class="hero-lead">
+          浜田市を拠点に、競技志向と楽しさを両立する卓球クラブ。
+          一人ひとりの挑戦をチームで支え、次のレベルへ進む場をつくります。
+        </p>
+        <div class="hero-actions">
+          <a href="mailto:blaze.hamada2018@gmail.com" class="button-primary"
             >練習参加を申し込む</a
           >
+          <a href="#practice" class="button-ghost">練習日程を見る</a>
         </div>
-        <div class="hero-image-wrap">
-          <img src="./img/main.png" alt="Blazeメンバー" class="hero-image" />
-        </div>
+        <ul class="hero-metrics">
+          <li><span>2018</span>創立</li>
+          <li><span>14</span>メンバー</li>
+          <li><span>4</span>練習拠点</li>
+        </ul>
+      </section>
+
+      <section class="visual-panel">
+        <img src="./img/main.png" alt="Blazeメンバー" />
       </section>
 
       <section class="section" id="about">
-        <h2 class="section-title">クラブ紹介</h2>
-        <div class="glass-card stats-grid">
-          <div>
-            <p class="label">活動拠点</p>
-            <p class="value">島根県浜田市</p>
-          </div>
-          <div>
-            <p class="label">創立</p>
-            <p class="value">2018年</p>
-          </div>
-          <div>
-            <p class="label">代表</p>
-            <p class="value">佐々本 健太</p>
-          </div>
-          <div>
-            <p class="label">メンバー</p>
-            <p class="value">14名（男性11名 / 女性3名）</p>
-          </div>
-          <div>
-            <p class="label">年齢層</p>
-            <p class="value">20代後半〜30代前半</p>
-          </div>
+        <div class="section-heading">
+          <p class="section-kicker">ABOUT BLAZE</p>
+          <h2>クラブ紹介</h2>
+        </div>
+        <div class="about-grid">
+          <article class="card large-card">
+            <h3>競技力とコミュニティの両立</h3>
+            <p>
+              Blazeは経験者を中心に、より高いレベルを目指して練習しています。
+              同時に、初心者やブランクのある方にも安心して参加いただける
+              オープンな雰囲気を大切にしています。
+            </p>
+          </article>
+          <article class="card info-list">
+            <dl>
+              <div><dt>活動拠点</dt><dd>島根県浜田市</dd></div>
+              <div><dt>代表</dt><dd>佐々本 健太</dd></div>
+              <div><dt>年齢層</dt><dd>20代後半〜30代前半</dd></div>
+              <div><dt>構成</dt><dd>14名（男性11名 / 女性3名）</dd></div>
+            </dl>
+          </article>
         </div>
       </section>
 
       <section class="section" id="practice">
-        <h2 class="section-title">練習情報</h2>
+        <div class="section-heading">
+          <p class="section-kicker">PRACTICE SCHEDULE</p>
+          <h2>練習情報</h2>
+        </div>
         <div class="practice-grid">
-          <article class="glass-card practice-card">
+          <article class="card practice-card">
             <h3>原井小学校</h3>
-            <p>毎週月曜 19:00〜21:00</p>
-            <p>参加費：100〜150円</p>
+            <p class="meta">毎週月曜 19:00〜21:00 / 参加費：100〜150円</p>
             <iframe
               src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3272.289212470998!2d132.06785607575318!3d34.899190972849894!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x355a577a55690c51%3A0xa1d64a08519fbece!2z5rWc55Sw5biC56uL5Y6f5LqV5bCP5a2m5qCh!5e0!3m2!1sja!2sjp!4v1700831117295!5m2!1sja!2sjp"
               loading="lazy"
@@ -108,10 +119,9 @@
             ></iframe>
           </article>
 
-          <article class="glass-card practice-card">
+          <article class="card practice-card">
             <h3>島根県立体育館</h3>
-            <p>不定期土日 13:00〜17:00</p>
-            <p>参加費：人数・施設により変動</p>
+            <p class="meta">不定期土日 13:00〜17:00 / 参加費：人数・施設により変動</p>
             <iframe
               src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3272.11715848552!2d132.09100307575335!3d34.903509272848346!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x355a59ea38c471df%3A0xca7c3841dc70293f!2z5bO25qC555yM56uL5L2T6IKy6aSo!5e0!3m2!1sja!2sjp!4v1700849387560!5m2!1sja!2sjp"
               loading="lazy"
@@ -120,10 +130,9 @@
             ></iframe>
           </article>
 
-          <article class="glass-card practice-card">
+          <article class="card practice-card">
             <h3>島根県立石見武道館</h3>
-            <p>不定期土日 13:00〜17:00</p>
-            <p>参加費：人数により変動</p>
+            <p class="meta">不定期土日 13:00〜17:00 / 参加費：人数により変動</p>
             <iframe
               src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3272.11715848552!2d132.09100307575335!3d34.903509272848346!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x355a59ebd0403d7f%3A0x7634701ba68009f!2z5bO25qC555yM56uL55-z6KaL5q2m6YGT6aSo!5e0!3m2!1sja!2sjp!4v1700849358083!5m2!1sja!2sjp"
               loading="lazy"
@@ -132,10 +141,9 @@
             ></iframe>
           </article>
 
-          <article class="glass-card practice-card">
+          <article class="card practice-card">
             <h3>島根県立浜田ろう学校</h3>
-            <p>不定期土曜 8:45〜12:00</p>
-            <p>参加費：無料</p>
+            <p class="meta">不定期土曜 8:45〜12:00 / 参加費：無料</p>
             <iframe
               src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3272.11715848552!2d132.09100307575335!3d34.903509272848346!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x355a59ebd0403d7f%3A0x7634701ba68009f!2z5bO25qC555yM56uL55-z6KaL5q2m6YGT6aSo!5e0!3m2!1sja!2sjp!4v1700849358083!5m2!1sja!2sjp"
               loading="lazy"
@@ -147,20 +155,27 @@
       </section>
 
       <section class="section" id="uniform">
-        <h2 class="section-title">チームユニフォーム</h2>
-        <div class="glass-card uniform-card">
-          <img src="./img/uniform.jpg" alt="Blazeのチームユニフォーム" />
+        <div class="section-heading">
+          <p class="section-kicker">TEAM STYLE</p>
+          <h2>チームユニフォーム</h2>
         </div>
+        <article class="card uniform-card">
+          <img src="./img/uniform.jpg" alt="Blazeのチームユニフォーム" />
+        </article>
       </section>
 
       <section class="section" id="contact">
-        <div class="contact-card">
-          <h2>まずは見学・体験から</h2>
-          <p>お気軽にメールでご連絡ください。日程調整のうえ、ご案内します。</p>
-          <a href="mailto:blaze.hamada2018@gmail.com" class="cta-button"
+        <article class="contact-banner">
+          <p class="section-kicker">JOIN US</p>
+          <h2>見学・体験参加を受付中</h2>
+          <p>
+            卓球が上手くなりたい、仲間と真剣に取り組みたい方へ。
+            まずは気軽にご連絡ください。
+          </p>
+          <a href="mailto:blaze.hamada2018@gmail.com" class="button-primary"
             >練習参加希望はこちら</a
           >
-        </div>
+        </article>
       </section>
     </main>
 

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
     <header class="site-header" id="top">
       <a href="#top" class="brand">
         <img src="./img/blaze_logo.png" alt="Blazeロゴ" class="brand-logo" />
-        <span class="brand-text">BLAZE</span>
+        <span class="brand-text">浜田BLAZE（ブレイズ）</span>
       </a>
       <nav class="site-nav" aria-label="メインナビゲーション">
         <a href="#about">クラブ紹介</a>
@@ -54,10 +54,8 @@
       </section>
 
       <section class="hero">
-        <p class="eyebrow">浜田市卓球クラブ BLAZE</p>
         <h1>
-          強く、楽しく、
-          <span>浜田で卓球。</span>
+          <span>浜田で卓球</span>
         </h1>
         <p class="hero-lead">
           Blazeは浜田市を拠点に活動する卓球クラブです。競技志向とコミュニティの温かさを両立し、
@@ -67,7 +65,7 @@
           <a href="mailto:blaze.hamada2018@gmail.com" class="button-primary"
             >練習参加を申し込む</a
           >
-          <a href="#practice" class="button-ghost">練習日程を見る</a>
+          <a href="#practice" class="button-ghost">練習情報を見る</a>
         </div>
         <ul class="hero-metrics">
           <li><span>2018</span>創立</li>
@@ -78,14 +76,14 @@
 
       <section class="section" id="about">
         <div class="section-heading">
-          <p class="section-kicker">クラブ情報</p>
           <h2>クラブ紹介</h2>
         </div>
         <div class="about-grid plain-block">
           <div>
             <h3>競技力とコミュニティの両立</h3>
             <p>
-              経験者を中心に、より高いレベルを目指して練習しています。同時に、初心者やブランクのある方でも参加しやすい、
+              経験者を中心に練習しています。
+              <br/>ブランクのある方でも参加しやすい、
               オープンな雰囲気づくりを大切にしています。
             </p>
           </div>
@@ -100,7 +98,6 @@
 
       <section class="section" id="practice">
         <div class="section-heading">
-          <p class="section-kicker">練習スケジュール</p>
           <h2>練習情報</h2>
         </div>
         <div class="practice-grid">
@@ -152,7 +149,6 @@
 
       <section class="section" id="uniform">
         <div class="section-heading">
-          <p class="section-kicker">チームスタイル</p>
           <h2>チームユニフォーム</h2>
         </div>
         <article class="uniform-panel">
@@ -162,7 +158,6 @@
 
       <section class="section" id="contact">
         <article class="contact-banner">
-          <p class="section-kicker">参加受付中</p>
           <h2>見学・体験参加を受付中</h2>
           <p>
             卓球がもっと上手くなりたい方、仲間と真剣に取り組みたい方へ。まずはお気軽にご連絡ください。

--- a/index.html
+++ b/index.html
@@ -52,8 +52,7 @@
       <section class="hero">
         <p class="eyebrow">浜田市卓球クラブ BLAZE</p>
         <h1>
-          強く、楽しく、
-          <span>誇れる卓球を。</span>
+          <span>卓球やらん？</span>
         </h1>
         <p class="hero-lead">
           Blazeは浜田市を拠点に活動する卓球クラブです。

--- a/index.html
+++ b/index.html
@@ -12,141 +12,163 @@
         dataLayer.push(arguments);
       }
       gtag("js", new Date());
-
       gtag("config", "G-6P883EZ2M3");
     </script>
+
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Blazeは浜田市の卓球クラブで、20代後半から30代前半の13名のメンバーが活動しています。練習は原井小学校や島根県立体育館などで不定期に行われています。無料で参加できる練習もあります。チームユニフォームの詳細もご覧ください。"
+      content="Blazeは浜田市の卓球クラブです。練習スケジュールや参加方法、チーム情報を掲載しています。"
     />
+    <title>Blaze - 浜田市の卓球クラブ</title>
+
     <link rel="stylesheet" type="text/css" href="./css/reset.css" />
     <link rel="stylesheet" type="text/css" href="./css/style.css" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&display=swap"
       rel="stylesheet"
     />
-    <link
-      data-react-helmet="true"
-      rel="icon"
-      type="image/png"
-      sizes="32x32"
-      href="/favicon.ico"
-    />
-
-    <title>Blaze - 浜田市の卓球クラブ</title>
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon.ico" />
   </head>
   <body>
-    <header>
-      <div id="logo-container">
-        <img id="logo" src="./img/blaze_logo.png" alt="サイトのロゴ" />
-      </div>
+    <div class="bg-layer"></div>
+
+    <header class="site-header">
+      <a href="#top" class="brand" id="top">
+        <img src="./img/blaze_logo.png" alt="Blazeロゴ" class="brand-logo" />
+        <span class="brand-text">BLAZE</span>
+      </a>
+      <nav class="site-nav" aria-label="メインナビゲーション">
+        <a href="#about">クラブ紹介</a>
+        <a href="#practice">練習情報</a>
+        <a href="#uniform">ユニフォーム</a>
+        <a href="#contact">参加方法</a>
+      </nav>
     </header>
+
     <main>
-      <section id="about-blaze"><img src="./img/main.png" /></section>
-      <div class="bg"></div>
-      <div class="bg bg2"></div>
-      <div class="bg bg3"></div>
-      <section id="contact">
-        <div id="contact-button">
-          <a href="mailto:blaze.hamada2018@gmail.com" class="gradient4"
-            >練習参加希望はこちらから</a
+      <section class="hero">
+        <div class="hero-content">
+          <p class="badge">Shimane Hamada Table Tennis Club</p>
+          <h1>熱く、楽しく、
+            <span>本気で卓球。</span>
+          </h1>
+          <p>
+            Blazeは、浜田市を拠点に活動する卓球クラブです。経験者はもちろん、
+            向上心のある方を歓迎しています。
+          </p>
+          <a href="mailto:blaze.hamada2018@gmail.com" class="cta-button"
+            >練習参加を申し込む</a
+          >
+        </div>
+        <div class="hero-image-wrap">
+          <img src="./img/main.png" alt="Blazeメンバー" class="hero-image" />
+        </div>
+      </section>
+
+      <section class="section" id="about">
+        <h2 class="section-title">クラブ紹介</h2>
+        <div class="glass-card stats-grid">
+          <div>
+            <p class="label">活動拠点</p>
+            <p class="value">島根県浜田市</p>
+          </div>
+          <div>
+            <p class="label">創立</p>
+            <p class="value">2018年</p>
+          </div>
+          <div>
+            <p class="label">代表</p>
+            <p class="value">佐々本 健太</p>
+          </div>
+          <div>
+            <p class="label">メンバー</p>
+            <p class="value">14名（男性11名 / 女性3名）</p>
+          </div>
+          <div>
+            <p class="label">年齢層</p>
+            <p class="value">20代後半〜30代前半</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="practice">
+        <h2 class="section-title">練習情報</h2>
+        <div class="practice-grid">
+          <article class="glass-card practice-card">
+            <h3>原井小学校</h3>
+            <p>毎週月曜 19:00〜21:00</p>
+            <p>参加費：100〜150円</p>
+            <iframe
+              src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3272.289212470998!2d132.06785607575318!3d34.899190972849894!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x355a577a55690c51%3A0xa1d64a08519fbece!2z5rWc55Sw5biC56uL5Y6f5LqV5bCP5a2m5qCh!5e0!3m2!1sja!2sjp!4v1700831117295!5m2!1sja!2sjp"
+              loading="lazy"
+              referrerpolicy="no-referrer-when-downgrade"
+              title="原井小学校の地図"
+            ></iframe>
+          </article>
+
+          <article class="glass-card practice-card">
+            <h3>島根県立体育館</h3>
+            <p>不定期土日 13:00〜17:00</p>
+            <p>参加費：人数・施設により変動</p>
+            <iframe
+              src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3272.11715848552!2d132.09100307575335!3d34.903509272848346!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x355a59ea38c471df%3A0xca7c3841dc70293f!2z5bO25qC555yM56uL5L2T6IKy6aSo!5e0!3m2!1sja!2sjp!4v1700849387560!5m2!1sja!2sjp"
+              loading="lazy"
+              referrerpolicy="no-referrer-when-downgrade"
+              title="島根県立体育館の地図"
+            ></iframe>
+          </article>
+
+          <article class="glass-card practice-card">
+            <h3>島根県立石見武道館</h3>
+            <p>不定期土日 13:00〜17:00</p>
+            <p>参加費：人数により変動</p>
+            <iframe
+              src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3272.11715848552!2d132.09100307575335!3d34.903509272848346!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x355a59ebd0403d7f%3A0x7634701ba68009f!2z5bO25qC555yM56uL55-z6KaL5q2m6YGT6aSo!5e0!3m2!1sja!2sjp!4v1700849358083!5m2!1sja!2sjp"
+              loading="lazy"
+              referrerpolicy="no-referrer-when-downgrade"
+              title="石見武道館の地図"
+            ></iframe>
+          </article>
+
+          <article class="glass-card practice-card">
+            <h3>島根県立浜田ろう学校</h3>
+            <p>不定期土曜 8:45〜12:00</p>
+            <p>参加費：無料</p>
+            <iframe
+              src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3272.11715848552!2d132.09100307575335!3d34.903509272848346!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x355a59ebd0403d7f%3A0x7634701ba68009f!2z5bO25qC555yM56uL55-z6KaL5q2m6YGT6aSo!5e0!3m2!1sja!2sjp!4v1700849358083!5m2!1sja!2sjp"
+              loading="lazy"
+              referrerpolicy="no-referrer-when-downgrade"
+              title="浜田ろう学校の地図"
+            ></iframe>
+          </article>
+        </div>
+      </section>
+
+      <section class="section" id="uniform">
+        <h2 class="section-title">チームユニフォーム</h2>
+        <div class="glass-card uniform-card">
+          <img src="./img/uniform.jpg" alt="Blazeのチームユニフォーム" />
+        </div>
+      </section>
+
+      <section class="section" id="contact">
+        <div class="contact-card">
+          <h2>まずは見学・体験から</h2>
+          <p>お気軽にメールでご連絡ください。日程調整のうえ、ご案内します。</p>
+          <a href="mailto:blaze.hamada2018@gmail.com" class="cta-button"
+            >練習参加希望はこちら</a
           >
         </div>
       </section>
-      <section id="about-blaze">
-        <h1>当クラブについて</h1>
-        <p>活動拠点　　：　島根県浜田市</p>
-        <p>創立　　　　：　2018年</p>
-        <p>代表　　　　：　佐々本 健太</p>
-        <p>メンバー数　：　14名（男性11名：女性3名）</p>
-        <p>年齢層　　　：　20代後半~30代前半</p>
-      </section>
-      <section id="practice-environment">
-        <h1>練習</h1>
-        <div class="lesson-container">
-          <h2>原井小学校</h2>
-          <p>毎週月曜　19:00~21:00</p>
-          <p>参加費：100~150円</p>
-          <div class="map">
-            <iframe
-              src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3272.289212470998!2d132.06785607575318!3d34.899190972849894!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x355a577a55690c51%3A0xa1d64a08519fbece!2z5rWc55Sw5biC56uL5Y6f5LqV5bCP5a2m5qCh!5e0!3m2!1sja!2sjp!4v1700831117295!5m2!1sja!2sjp"
-              width="250"
-              height="150"
-              style="border: 0"
-              allowfullscreen=""
-              loading="lazy"
-              referrerpolicy="no-referrer-when-downgrade"
-            ></iframe>
-          </div>
-        </div>
-        <div class="lesson-container">
-          <h2>島根県立体育館</h2>
-          <p>不定期土日　13:00~17:00</p>
-          <p>参加費：人数・施設により変動</p>
-          <div class="map">
-            <iframe
-              src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3272.11715848552!2d132.09100307575335!3d34.903509272848346!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x355a59ea38c471df%3A0xca7c3841dc70293f!2z5bO25qC555yM56uL5L2T6IKy6aSo!5e0!3m2!1sja!2sjp!4v1700849387560!5m2!1sja!2sjp"
-              width="250"
-              height="150"
-              style="border: 0"
-              allowfullscreen=""
-              loading="lazy"
-              referrerpolicy="no-referrer-when-downgrade"
-            ></iframe>
-          </div>
-        </div>
-
-        <div class="lesson-container">
-          <h2>島根県立石見武道館</h2>
-          <p>不定期土日　13:00~17:00</p>
-          <p>参加費：人数により変動</p>
-          <div class="map">
-            <iframe
-              src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3272.11715848552!2d132.09100307575335!3d34.903509272848346!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x355a59ebd0403d7f%3A0x7634701ba68009f!2z5bO25qC555yM56uL55-z6KaL5q2m6YGT6aSo!5e0!3m2!1sja!2sjp!4v1700849358083!5m2!1sja!2sjp"
-              width="250"
-              height="150"
-              style="border: 0"
-              allowfullscreen=""
-              loading="lazy"
-              referrerpolicy="no-referrer-when-downgrade"
-            ></iframe>
-          </div>
-        </div>
-
-        <div class="lesson-container">
-          <h2>島根県立浜田ろう学校</h2>
-          <p>不定期土曜　8:45~12:00</p>
-          <p>参加費：無料</p>
-          <div class="map">
-            <iframe
-              src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3272.11715848552!2d132.09100307575335!3d34.903509272848346!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x355a59ebd0403d7f%3A0x7634701ba68009f!2z5bO25qC555yM56uL55-z6KaL5q2m6YGT6aSo!5e0!3m2!1sja!2sjp!4v1700849358083!5m2!1sja!2sjp"
-              width="250"
-              height="150"
-              style="border: 0"
-              allowfullscreen=""
-              loading="lazy"
-              referrerpolicy="no-referrer-when-downgrade"
-            ></iframe>
-          </div>
-        </div>
-      </section>
-
-      <section id="team-uniform">
-        <h1>チームユニフォーム</h1>
-        <img src="./img/uniform.jpg" class="uniform_img" />
-      </section>
     </main>
 
-    <footer>
-      <p id="page-top"><a href="#">Page Top</a></p>
-      <p id="copylight">
-        <a href="./privacy.html">
-          Copyright &copy; 2023 BLAZE All rights reserved.</a
-        >
+    <footer class="site-footer">
+      <a href="#top" class="page-top">Page Top</a>
+      <p>
+        <a href="./privacy.html">Copyright &copy; 2023 BLAZE All rights reserved.</a>
       </p>
     </footer>
-    <script src="./js/index.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -49,14 +49,18 @@
     </header>
 
     <main class="container">
+      <section class="visual-panel first-visual">
+        <img src="./img/main.png" alt="Blazeメンバー" />
+      </section>
+
       <section class="hero">
         <p class="eyebrow">浜田市卓球クラブ BLAZE</p>
         <h1>
-          <span>卓球やらん？</span>
+          強く、楽しく、
+          <span>浜田で卓球。</span>
         </h1>
         <p class="hero-lead">
-          Blazeは浜田市を拠点に活動する卓球クラブです。
-          競技志向とコミュニティの温かさを両立し、
+          Blazeは浜田市を拠点に活動する卓球クラブです。競技志向とコミュニティの温かさを両立し、
           一人ひとりが成長できる環境づくりを大切にしています。
         </p>
         <div class="hero-actions">
@@ -72,32 +76,25 @@
         </ul>
       </section>
 
-      <section class="visual-panel">
-        <img src="./img/main.png" alt="Blazeメンバー" />
-      </section>
-
       <section class="section" id="about">
         <div class="section-heading">
           <p class="section-kicker">クラブ情報</p>
           <h2>クラブ紹介</h2>
         </div>
-        <div class="about-grid">
-          <article class="card large-card">
+        <div class="about-grid plain-block">
+          <div>
             <h3>競技力とコミュニティの両立</h3>
             <p>
-              経験者を中心に、より高いレベルを目指して練習しています。
-              同時に、初心者やブランクのある方でも参加しやすい、
+              経験者を中心に、より高いレベルを目指して練習しています。同時に、初心者やブランクのある方でも参加しやすい、
               オープンな雰囲気づくりを大切にしています。
             </p>
-          </article>
-          <article class="card info-list">
-            <dl>
-              <div><dt>活動拠点</dt><dd>島根県浜田市</dd></div>
-              <div><dt>代表</dt><dd>佐々本 健太</dd></div>
-              <div><dt>年齢層</dt><dd>20代後半〜30代前半</dd></div>
-              <div><dt>構成</dt><dd>14名（男性11名 / 女性3名）</dd></div>
-            </dl>
-          </article>
+          </div>
+          <dl class="info-list">
+            <div><dt>活動拠点</dt><dd>島根県浜田市</dd></div>
+            <div><dt>代表</dt><dd>佐々本 健太</dd></div>
+            <div><dt>年齢層</dt><dd>20代後半〜30代前半</dd></div>
+            <div><dt>構成</dt><dd>14名（男性11名 / 女性3名）</dd></div>
+          </dl>
         </div>
       </section>
 
@@ -107,7 +104,7 @@
           <h2>練習情報</h2>
         </div>
         <div class="practice-grid">
-          <article class="card practice-card">
+          <article class="practice-item">
             <h3>原井小学校</h3>
             <p class="meta">毎週月曜 19:00〜21:00 / 参加費：100〜150円</p>
             <iframe
@@ -118,7 +115,7 @@
             ></iframe>
           </article>
 
-          <article class="card practice-card">
+          <article class="practice-item">
             <h3>島根県立体育館</h3>
             <p class="meta">不定期土日 13:00〜17:00 / 参加費：人数・施設により変動</p>
             <iframe
@@ -129,7 +126,7 @@
             ></iframe>
           </article>
 
-          <article class="card practice-card">
+          <article class="practice-item">
             <h3>島根県立石見武道館</h3>
             <p class="meta">不定期土日 13:00〜17:00 / 参加費：人数により変動</p>
             <iframe
@@ -140,7 +137,7 @@
             ></iframe>
           </article>
 
-          <article class="card practice-card">
+          <article class="practice-item">
             <h3>島根県立浜田ろう学校</h3>
             <p class="meta">不定期土曜 8:45〜12:00 / 参加費：無料</p>
             <iframe
@@ -158,7 +155,7 @@
           <p class="section-kicker">チームスタイル</p>
           <h2>チームユニフォーム</h2>
         </div>
-        <article class="card uniform-card">
+        <article class="uniform-panel">
           <img src="./img/uniform.jpg" alt="Blazeのチームユニフォーム" />
         </article>
       </section>
@@ -168,8 +165,7 @@
           <p class="section-kicker">参加受付中</p>
           <h2>見学・体験参加を受付中</h2>
           <p>
-            卓球がもっと上手くなりたい方、仲間と真剣に取り組みたい方へ。
-            まずはお気軽にご連絡ください。
+            卓球がもっと上手くなりたい方、仲間と真剣に取り組みたい方へ。まずはお気軽にご連絡ください。
           </p>
           <a href="mailto:blaze.hamada2018@gmail.com" class="button-primary"
             >練習参加希望はこちら</a

--- a/privacy.html
+++ b/privacy.html
@@ -28,9 +28,8 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon.ico" />
   </head>
   <body>
-    <div class="noise"></div>
-    <div class="aurora aurora-1"></div>
-    <div class="aurora aurora-2"></div>
+    <div class="bg-shape bg-shape-1"></div>
+    <div class="bg-shape bg-shape-2"></div>
 
     <header class="site-header" id="top">
       <a href="./index.html" class="brand">
@@ -45,7 +44,7 @@
     <main class="container privacy-main">
       <section class="section">
         <div class="section-heading">
-          <p class="section-kicker">PRIVACY POLICY</p>
+          <p class="section-kicker">個人情報保護方針</p>
           <h1>プライバシーポリシー</h1>
         </div>
         <article class="card privacy-card">
@@ -89,7 +88,7 @@
     </main>
 
     <footer class="site-footer">
-      <a href="#top" class="page-top">Page Top</a>
+      <a href="#top" class="page-top">ページトップへ</a>
       <p>Copyright &copy; 2023 BLAZE All rights reserved.</p>
     </footer>
   </body>

--- a/privacy.html
+++ b/privacy.html
@@ -28,9 +28,11 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon.ico" />
   </head>
   <body>
-    <div class="bg-layer"></div>
+    <div class="noise"></div>
+    <div class="aurora aurora-1"></div>
+    <div class="aurora aurora-2"></div>
 
-    <header class="site-header">
+    <header class="site-header" id="top">
       <a href="./index.html" class="brand">
         <img src="./img/blaze_logo.png" alt="Blazeロゴ" class="brand-logo" />
         <span class="brand-text">BLAZE</span>
@@ -40,10 +42,13 @@
       </nav>
     </header>
 
-    <main>
-      <section class="section privacy-section">
-        <h1 class="section-title">プライバシーポリシー</h1>
-        <div class="glass-card privacy-card">
+    <main class="container privacy-main">
+      <section class="section">
+        <div class="section-heading">
+          <p class="section-kicker">PRIVACY POLICY</p>
+          <h1>プライバシーポリシー</h1>
+        </div>
+        <article class="card privacy-card">
           <p>
             このウェブサイトでは、お客様の個人情報を尊重し、保護するために最善を尽くしています。以下に、収集する情報とその利用方法について説明いたします。
           </p>
@@ -79,12 +84,12 @@
           </p>
 
           <p>ご不明点がありましたら、お気軽にお問い合わせください。</p>
-        </div>
+        </article>
       </section>
     </main>
 
     <footer class="site-footer">
-      <a href="#" class="page-top">Page Top</a>
+      <a href="#top" class="page-top">Page Top</a>
       <p>Copyright &copy; 2023 BLAZE All rights reserved.</p>
     </footer>
   </body>

--- a/privacy.html
+++ b/privacy.html
@@ -12,85 +12,80 @@
         dataLayer.push(arguments);
       }
       gtag("js", new Date());
-
       gtag("config", "G-6P883EZ2M3");
     </script>
+
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Blaze - プライバシーポリシー</title>
+
     <link rel="stylesheet" type="text/css" href="./css/reset.css" />
     <link rel="stylesheet" type="text/css" href="./css/style.css" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&display=swap"
       rel="stylesheet"
     />
-    <link
-      data-react-helmet="true"
-      rel="icon"
-      type="image/png"
-      sizes="32x32"
-      href="/favicon.ico"
-    />
-    <title>Blaze - プライバシーポリシー</title>
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon.ico" />
   </head>
   <body>
-    <header>
-      <div id="logo-container">
-        <a href="./index.html">
-          <img id="logo" src="./img/blaze_logo.png" alt="サイトのロゴ" />
-        </a>
-      </div>
+    <div class="bg-layer"></div>
+
+    <header class="site-header">
+      <a href="./index.html" class="brand">
+        <img src="./img/blaze_logo.png" alt="Blazeロゴ" class="brand-logo" />
+        <span class="brand-text">BLAZE</span>
+      </a>
+      <nav class="site-nav" aria-label="メインナビゲーション">
+        <a href="./index.html">トップへ戻る</a>
+      </nav>
     </header>
+
     <main>
-      <div class="bg"></div>
-      <div class="bg bg2"></div>
-      <div class="bg bg3"></div>
-      <section id="privacy-policy">
-        <h1>プライバシーポリシー</h1>
-        <p>
-          このウェブサイトでは、お客様の個人情報を尊重し、保護するために最善を尽くしています。以下に、弊社がお客様から収集する情報とその利用方法について説明いたします。
-        </p>
+      <section class="section privacy-section">
+        <h1 class="section-title">プライバシーポリシー</h1>
+        <div class="glass-card privacy-card">
+          <p>
+            このウェブサイトでは、お客様の個人情報を尊重し、保護するために最善を尽くしています。以下に、収集する情報とその利用方法について説明いたします。
+          </p>
 
-        <h2>収集される情報</h2>
-        <p>
-          当ウェブサイトでは、お問い合わせフォームやメールを通じて、お客様からのお名前やメールアドレスなどの個人情報を収集することがあります。また、ウェブサイトの利用状況に関する情報（アクセスログなど）も収集される場合があります。
-        </p>
+          <h2>収集される情報</h2>
+          <p>
+            お問い合わせフォームやメールを通じて、お名前やメールアドレスなどの個人情報を収集することがあります。また、アクセスログなどサイトの利用状況に関する情報を収集する場合があります。
+          </p>
 
-        <h2>収集した情報の利用</h2>
-        <p>
-          収集した個人情報は、お客様へのサービス提供やご連絡のために利用されます。例えば、お問い合わせに対する回答やサービスの提供の際に使用されることがあります。また、ウェブサイトの利用状況の統計的な分析に活用することがあります。
-        </p>
+          <h2>収集した情報の利用</h2>
+          <p>
+            収集した個人情報は、お問い合わせへの回答や必要な連絡など、サービス提供のために利用します。また、ウェブサイト改善のための統計的分析に活用する場合があります。
+          </p>
 
-        <h2>情報の共有と第三者への提供</h2>
-        <p>
-          弊社は、お客様の個人情報を本人の同意なしに第三者に提供することはありません。ただし、法令に基づく場合や、お客様が明示的に同意した場合は除きます。
-        </p>
+          <h2>情報の共有と第三者提供</h2>
+          <p>
+            ご本人の同意なしに、個人情報を第三者へ提供することはありません。ただし、法令に基づく場合を除きます。
+          </p>
 
-        <h2>情報の保管とセキュリティ</h2>
-        <p>
-          収集した個人情報は適切な方法で保管され、不正アクセスや紛失、改ざん、漏洩などから保護するための措置が講じられています。
-        </p>
+          <h2>情報の保管とセキュリティ</h2>
+          <p>
+            収集した個人情報は適切に管理し、不正アクセス・紛失・改ざん・漏えいを防ぐための対策を講じます。
+          </p>
 
-        <h2>クッキーについて</h2>
-        <p>
-          当ウェブサイトではクッキーを使用して、利用者のブラウザに情報を送信することがあります。クッキーは個別の利用者を識別するために使用されるものであり、個人を特定する情報を収集するものではありません。
-        </p>
+          <h2>クッキーについて</h2>
+          <p>
+            当サイトでは、利便性向上のためにCookieを使用することがあります。Cookieには個人を特定する情報は含まれません。
+          </p>
 
-        <h2>プライバシーポリシーの変更</h2>
-        <p>
-          弊社は、プライバシーポリシーを変更する場合があります。変更がある場合は、本ページでお知らせいたします。
-        </p>
+          <h2>ポリシーの変更</h2>
+          <p>
+            本ポリシーは必要に応じて変更する場合があります。変更後の内容は本ページにてお知らせします。
+          </p>
 
-        <p>ご不明点やご質問がある場合は、お気軽にお問い合わせください。</p>
+          <p>ご不明点がありましたら、お気軽にお問い合わせください。</p>
+        </div>
       </section>
     </main>
 
-    <footer>
-      <p id="page-top"><a href="#">Page Top</a></p>
-      <p id="copylight">
-        <a href="#"> Copyright &copy; 2023 BLAZE All rights reserved.</a>
-      </p>
+    <footer class="site-footer">
+      <a href="#" class="page-top">Page Top</a>
+      <p>Copyright &copy; 2023 BLAZE All rights reserved.</p>
     </footer>
-
-    <script src="./js/index.js"></script>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- 既存のページは装飾やレイアウトが古く単調だったため、ブランド性と視認性を高める目的でUIを近代化しました。 
- 情報の見やすさ（練習情報・参加導線）とモバイル対応を改善するためにレイアウトを整理しました。 
- 一貫したデザイントーンを全ページに適用してメンテナンス性とユーザー体験を向上させます。 

### Description
- `index.html` を全面的に再構成し、ヒーローセクション、固定ヘッダーのナビゲーション、カード型レイアウト、強調されたCTA導線を追加しました。 
- `privacy.html` を同一のデザインシステムに統一し、可読性の高いカード構造へ変更しました。 
- `css/style.css` を大幅に刷新してダークグラデーション背景、ガラスモーフィズム風のカード、レスポンシブグリッド、タイポグラフィ調整、高解像度フォント（`Noto Sans JP` の重み拡張）を導入しました。 
- 使われていない `./js/index.js` の読み込みを削除し、地図の iframe タグに `title` 属性などアクセシビリティ向上のための調整を行いました。 

### Testing
- ローカルサーバーで `python3 -m http.server 4173` を実行して表示確認を行い、ページが正しく配信されることを確認しました（成功）。 
- Playwright スクリプトでトップページを開きフルページのスクリーンショットを取得して表示結果を検証しました（成功、アーティファクト: `browser:/tmp/codex_browser_invocations/3c41c915b9aa17e4/artifacts/artifacts/blaze-home.png`）。 
- `git status` 等で変更差分を確認し、対象ファイル (`index.html`, `privacy.html`, `css/style.css`) の更新が反映されていることを確認しました（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993e6a057a0832f92604850d2160d53)