### PR TITLE
Netlify警告対応とSEO強化、クラブ紹介セクションの下線削除

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -221,7 +221,6 @@ body {
   margin-top: 16px;
   padding: 22px 0;
   border-top: 2px solid #ced7e8;
-  border-bottom: 1px solid #dbe1ee;
 }
 
 .about-grid {

--- a/index.html
+++ b/index.html
@@ -1,6 +1,39 @@
 <!DOCTYPE html>
 <html lang="ja">
   <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="format-detection" content="telephone=no" />
+    <meta name="robots" content="index, follow" />
+    <meta name="theme-color" content="#ff4d2d" />
+    <meta
+      name="description"
+      content="Blazeは浜田市の卓球クラブです。練習スケジュールや参加方法、チーム情報を掲載しています。"
+    />
+    <link rel="canonical" href="https://hamada-blaze.netlify.app/" />
+
+    <meta property="og:locale" content="ja_JP" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="浜田BLAZE（ブレイズ）" />
+    <meta property="og:title" content="Blaze - 浜田市の卓球クラブ" />
+    <meta
+      property="og:description"
+      content="Blazeは浜田市の卓球クラブです。練習スケジュールや参加方法、チーム情報を掲載しています。"
+    />
+    <meta property="og:url" content="https://hamada-blaze.netlify.app/" />
+    <meta property="og:image" content="https://hamada-blaze.netlify.app/img/main.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Blaze - 浜田市の卓球クラブ" />
+    <meta
+      name="twitter:description"
+      content="Blazeは浜田市の卓球クラブです。練習スケジュールや参加方法、チーム情報を掲載しています。"
+    />
+    <meta name="twitter:image" content="https://hamada-blaze.netlify.app/img/main.png" />
+    <title>Blaze - 浜田市の卓球クラブ</title>
+
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon.ico" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <!-- Google tag (gtag.js) -->
     <script
       async
@@ -15,21 +48,31 @@
       gtag("config", "G-6P883EZ2M3");
     </script>
 
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta
-      name="description"
-      content="Blazeは浜田市の卓球クラブです。練習スケジュールや参加方法、チーム情報を掲載しています。"
-    />
-    <title>Blaze - 浜田市の卓球クラブ</title>
-
     <link rel="stylesheet" type="text/css" href="./css/reset.css" />
     <link rel="stylesheet" type="text/css" href="./css/style.css" />
     <link
       href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&display=swap"
       rel="stylesheet"
     />
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon.ico" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "SportsClub",
+        "name": "浜田BLAZE（ブレイズ）",
+        "description": "Blazeは浜田市の卓球クラブです。練習スケジュールや参加方法、チーム情報を掲載しています。",
+        "url": "https://hamada-blaze.netlify.app/",
+        "logo": "https://hamada-blaze.netlify.app/img/blaze_logo.png",
+        "image": "https://hamada-blaze.netlify.app/img/main.png",
+        "email": "blaze.hamada2018@gmail.com",
+        "sport": "卓球",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "浜田市",
+          "addressRegion": "島根県",
+          "addressCountry": "JP"
+        }
+      }
+    </script>
   </head>
   <body>
     <div class="bg-shape bg-shape-1"></div>
@@ -49,7 +92,7 @@
     </header>
 
     <main class="container">
-      <section class="visual-panel first-visual">
+      <section class="visual-panel first-visual" aria-label="クラブメインビジュアル">
         <img src="./img/main.png" alt="Blazeメンバー" />
       </section>
 
@@ -152,7 +195,7 @@
           <h2>チームユニフォーム</h2>
         </div>
         <article class="uniform-panel">
-          <img src="./img/uniform.jpg" alt="Blazeのチームユニフォーム" />
+          <img src="./img/uniform.jpg" alt="Blazeのチームユニフォーム" loading="lazy" />
         </article>
       </section>
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,22 @@
+[build]
+  publish = "."
+
+[build.environment]
+  NETLIFY_IMAGE_TAG = "noble"
+
+[build.processing]
+  skip_processing = false
+
+[build.processing.css]
+  bundle = true
+  minify = true
+
+[build.processing.js]
+  bundle = true
+  minify = true
+
+[build.processing.html]
+  pretty_urls = true
+
+[build.processing.images]
+  compress = true


### PR DESCRIPTION
### Motivation
- Netlifyのビルド環境警告を解消しつつ、検索とSNSでの表示品質を高める目的でサイトメタとビルド設定の強化を行いました。 
- クラブ紹介セクション下の不要な線がデザイン上目立っていたため視覚的に削除しました。 

### Description
- `netlify.toml` を追加して `publish = " . "` と `NETLIFY_IMAGE_TAG = "noble"` を設定し、ビルド処理（CSS/JSバンドル・最小化、HTML pretty URLs、画像圧縮）を明示しました. 
- `index.html` の `<head>` に canonical、`robots`、`theme-color`、OGP/TwitterカードなどのSEOメタを追加し、`SportsClub` の構造化データ(JSON-LD)を挿入しました。 
- フォントの `preconnect` を追加し、メインビジュアルに `aria-label`、ユニフォーム画像に `loading="lazy"` を付与してパフォーマンスとアクセシビリティを改善しました。 
- `css/style.css` の `.plain-block` から `border-bottom` を削除してクラブ紹介セクション最下部の不要なラインを取り除きました。 

### Testing
- `git diff --check` を実行して差分の体裁チェックは成功しました。 
- ローカルで `python3 -m http.server --directory /workspace/blaze 4173` を起動してページを表示確認でき、サーバーは応答しました。 
- Playwright スクリプトで `http://127.0.0.1:4173/index.html` を開いてフルページのスクリーンショットを取得する確認は成功しました（アーティファクト生成済み）。 
- 環境検証として `tomllib` を使った `netlify.toml` のパース確認スクリプトは実行環境に `tomllib` がなく失敗しましたが、`netlify.toml` ファイル自体は作成・コミット済みです。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993f519285c832f9c41a9e6819bf4fe)